### PR TITLE
Adding Github Actions to validate dependancies for Ubuntu 18.04

### DIFF
--- a/.github/workflows/ubuntu1804.yml
+++ b/.github/workflows/ubuntu1804.yml
@@ -1,4 +1,4 @@
-name: CI - Ubuntu 18.04
+name: Ubuntu 18.04
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/ubuntu1804.yml
+++ b/.github/workflows/ubuntu1804.yml
@@ -5,10 +5,10 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: 
-      - hacktoberfest/gh-actions-ubuntu1804
+      - hacktoberfest/add-gh-actions
   pull_request:
     branches:
-      - hacktoberfest/gh-actions-ubuntu1804
+      - hacktoberfest/add-gh-actions
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/ubuntu1804.yml
+++ b/.github/workflows/ubuntu1804.yml
@@ -33,7 +33,9 @@ jobs:
           sudo apt install apt-transport-https -y
           sudo apt install build-essential -y
           sudo apt remove mongo* -y
-        
+        # Default mongodb install needs to be removed:
+        # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md#databases
+
       - name: Install hpfeeds
         run: |
           cd /opt/mhn/scripts/

--- a/.github/workflows/ubuntu1804.yml
+++ b/.github/workflows/ubuntu1804.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  install-mhn:
+  install-mhn-dependencies:
     runs-on: ubuntu-18.04
 
     steps:
@@ -31,7 +31,7 @@ jobs:
           sudo apt install -y python-pip
           sudo pip install --upgrade pip
           sudo apt install apt-transport-https -y
-          sudo apt intall build-essential -y
+          sudo apt install build-essential -y
         
       - name: Install hpfeeds
         run: sudo bash /opt/mhn/scripts/install_hpfeeds.sh

--- a/.github/workflows/ubuntu1804.yml
+++ b/.github/workflows/ubuntu1804.yml
@@ -1,0 +1,43 @@
+name: CI - Ubuntu 18.04
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: 
+      - hacktoberfest/gh-actions-ubuntu1804
+  pull_request:
+    branches:
+      - hacktoberfest/gh-actions-ubuntu1804
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  install-mhn:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: sudo mkdir /opt/mhn/
+
+      - name: Clone latest MHN
+        run: sudo git clone https://github.com/pwnlandia/mhn.git /opt/mhn/
+      
+      - name: Install MHN dependencies
+        run: |
+          sudo apt update && sudo apt upgrade -y
+          sudo apt install -y python-pip
+          sudo pip install --upgrade pip
+          sudo apt install apt-transport-https -y
+          sudo apt intall build-essential -y
+        
+      - name: Install hpfeeds
+        run: sudo bash /opt/mhn/scripts/install_hpfeeds.sh
+      
+      - name: Install mnemosyne
+        run: sudo bash /opt/mhn/scripts/install_mnemosyne.sh
+      
+      - name: Install honeymap
+        run: sudo bash /opt/mhn/scripts/install_honeymap.sh

--- a/.github/workflows/ubuntu1804.yml
+++ b/.github/workflows/ubuntu1804.yml
@@ -20,12 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Create MHN dir
-        run: sudo mkdir /opt/mhn/
-
       - name: Clone latest MHN
         run: |
-          cd /opt/mhn/
+          cd /opt/
           sudo git clone https://github.com/pwnlandia/mhn.git
       
       - name: Install MHN dependencies

--- a/.github/workflows/ubuntu1804.yml
+++ b/.github/workflows/ubuntu1804.yml
@@ -20,10 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: sudo mkdir /opt/mhn/
+      - name: Create MHN dir
+        run: sudo mkdir /opt/mhn/
 
       - name: Clone latest MHN
-        run: sudo git clone https://github.com/pwnlandia/mhn.git /opt/mhn/
+        run: |
+          cd /opt/mhn/
+          sudo git clone https://github.com/pwnlandia/mhn.git
       
       - name: Install MHN dependencies
         run: |
@@ -34,10 +37,16 @@ jobs:
           sudo apt install build-essential -y
         
       - name: Install hpfeeds
-        run: sudo bash /opt/mhn/scripts/install_hpfeeds.sh
+        run: |
+          cd /opt/mhn/scripts/
+          sudo ./install_hpfeeds.sh
       
       - name: Install mnemosyne
-        run: sudo bash /opt/mhn/scripts/install_mnemosyne.sh
+        run: |
+          cd /opt/mhn/scripts/
+          sudo ./install_mnemosyne.sh
       
       - name: Install honeymap
-        run: sudo bash /opt/mhn/scripts/install_honeymap.sh
+        run: |
+          cd /opt/mhn/scripts/
+          sudo ./install_honeymap.sh

--- a/.github/workflows/ubuntu1804.yml
+++ b/.github/workflows/ubuntu1804.yml
@@ -32,6 +32,7 @@ jobs:
           sudo pip install --upgrade pip
           sudo apt install apt-transport-https -y
           sudo apt install build-essential -y
+          sudo apt remove mongo* -y
         
       - name: Install hpfeeds
         run: |


### PR DESCRIPTION
Github's Ubuntu 18.04 Runner comes with a pre-configured MongoDB apt source. See the [Github Ubuntu 18.04](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md#databases) explanation for details.

I'm still unsure how to test the server install script since it relies on a config file that contains pseudo-secrets.