### PR TITLE
Add Github Actions Workflow for Ubuntu 20.04

### DIFF
--- a/.github/workflows/ubuntu2004.yml
+++ b/.github/workflows/ubuntu2004.yml
@@ -1,14 +1,14 @@
-name: Ubuntu 18.04
+name: Ubuntu 20.04
 
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: 
-      - gh-actions-ubuntu2004
+      - add-gh-actions
   pull_request:
     branches:
-      - gh-actions-ubuntu2004
+      - add-gh-actions
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This will fail until python 2 is dropped in favor of python 3 or until the server's scripts up updated to include Ubuntu 20.04