### PR TITLE
Upgrade Install of hpfeeds.

### DIFF
--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -42,13 +42,14 @@ pip install cffi
 pip install pyopenssl==17.3.0
 pip install pymongo
 pip install .
+pip install -r requirements.txt
 deactivate
 
 mkdir -p /var/log/mhn
 mkdir -p /etc/supervisor/
 mkdir -p /etc/supervisor/conf.d
 
-cat >> /opt/hpfeeds/users.json <<EOF
+cat > /opt/hpfeeds/users.json <<EOF
 {
   "my-user-ident": {
     "owner": "my-owner",
@@ -59,9 +60,9 @@ cat >> /opt/hpfeeds/users.json <<EOF
 }
 EOF
 
-cat >> /etc/supervisor/conf.d/hpfeeds-broker.conf <<EOF 
+cat > /etc/supervisor/conf.d/hpfeeds-broker.conf <<EOF 
 [program:hpfeeds-broker]
-command=/opt/hpfeeds/env/bin/python /opt/hpfeeds/env/bin/hpfeeds-broker -e tcp:port=10000 --exporter=0.0.0.0:9431 --auth=/opt/hpfeeds/users.json
+command=/bin/bash -c 'source /opt/hpfeeds/env/bin/activate && /opt/hpfeeds/env/bin/python /opt/hpfeeds/env/bin/hpfeeds-broker -e tcp:port=10000 --exporter=0.0.0.0:9431 --auth=/opt/hpfeeds/users.json'
 directory=/opt/hpfeeds
 stdout_logfile=/var/log/mhn/hpfeeds-broker.log
 stderr_logfile=/var/log/mhn/hpfeeds-broker.err

--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -39,8 +39,6 @@ $VIRTUALENV -p $PYTHON env
 pip install cffi
 pip install pyopenssl==17.3.0
 pip install pymongo
-pip install -e git+https://github.com/couozu/pyev.git#egg=pyev
-pip install -e git+https://github.com/pwnlandia/evnet.git#egg=evnet-dev
 pip install .
 deactivate
 

--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -27,18 +27,10 @@ bash install_mongo.sh
 
 $PIP install virtualenv
 
-cd /tmp
-wget https://github.com/pwnlandia/hpfeeds/releases/download/libev-4.15/libev-4.15.tar.gz
-tar zxvf libev-4.15.tar.gz 
-cd libev-4.15
-./configure && make && make install
-ldconfig /usr/local/lib/
-
-
 mkdir -p /opt
 cd /opt
 rm -rf /opt/hpfeeds
-git clone https://github.com/pwnlandia/hpfeeds
+git clone https://github.com/hpfeeds/hpfeeds.git
 chmod 755 -R hpfeeds
 cd hpfeeds
 $VIRTUALENV -p $PYTHON env

--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -49,20 +49,9 @@ mkdir -p /var/log/mhn
 mkdir -p /etc/supervisor/
 mkdir -p /etc/supervisor/conf.d
 
-cat > /opt/hpfeeds/users.json <<EOF
-{
-  "my-user-ident": {
-    "owner": "my-owner",
-    "secret": "my-really-strong-passphrase",
-    "subchans": ["chan1"],
-    "pubchans": ["chan2"]
-  }
-}
-EOF
-
 cat > /etc/supervisor/conf.d/hpfeeds-broker.conf <<EOF 
 [program:hpfeeds-broker]
-command=/bin/bash -c 'source /opt/hpfeeds/env/bin/activate && /opt/hpfeeds/env/bin/python /opt/hpfeeds/env/bin/hpfeeds-broker -e tcp:port=10000 --exporter=0.0.0.0:9431 --auth=/opt/hpfeeds/users.json'
+command=/bin/bash -c 'source /opt/hpfeeds/env/bin/activate && /opt/hpfeeds/env/bin/python /opt/hpfeeds/env/bin/hpfeeds-broker -e tcp:port=10000 --exporter=0.0.0.0:9431 --auth="mongodb://127.0.0.1:27017/hpfeeds"'
 directory=/opt/hpfeeds
 stdout_logfile=/var/log/mhn/hpfeeds-broker.log
 stderr_logfile=/var/log/mhn/hpfeeds-broker.err

--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -9,11 +9,9 @@ MHN_HOME=$SCRIPTS/..
 if [ -f /etc/debian_version ]; then
     apt-get -y update
     # this needs to be installed before calling "which pip", otherwise that command fails
-    apt-get -y install libffi-dev build-essential python-pip python-dev python3 python3-pip git libssl-dev supervisor
+    apt-get -y install python3 python3-pip git supervisor
 
-    PYTHON=`which python`
     PYTHON3=`which python3`
-    PIP=`which pip`
     PIP3=`which pip3`
     $PIP3 install virtualenv
     VIRTUALENV=`which virtualenv`

--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -39,8 +39,9 @@ $VIRTUALENV -p $PYTHON3 env
 . env/bin/activate
 
 pip install cffi
-pip install pyopenssl==17.3.0
+pip install pyopenssl==23.1.1
 pip install pymongo
+pip install motor==2.5.1
 pip install .
 pip install -r requirements.txt
 deactivate

--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -9,11 +9,13 @@ MHN_HOME=$SCRIPTS/..
 if [ -f /etc/debian_version ]; then
     apt-get -y update
     # this needs to be installed before calling "which pip", otherwise that command fails
-    apt-get -y install libffi-dev build-essential python-pip python-dev git libssl-dev supervisor
+    apt-get -y install libffi-dev build-essential python-pip python-dev python3 python3-pip git libssl-dev supervisor
 
     PYTHON=`which python`
+    PYTHON3=`which python3`
     PIP=`which pip`
-    $PIP install virtualenv
+    PIP3=`which pip3`
+    $PIP3 install virtualenv
     VIRTUALENV=`which virtualenv`
 
 else
@@ -25,7 +27,7 @@ ldconfig /usr/local/lib/
 
 bash install_mongo.sh
 
-$PIP install virtualenv
+$PIP3 install virtualenv
 
 mkdir -p /opt
 cd /opt
@@ -33,7 +35,7 @@ rm -rf /opt/hpfeeds
 git clone https://github.com/hpfeeds/hpfeeds.git
 chmod 755 -R hpfeeds
 cd hpfeeds
-$VIRTUALENV -p $PYTHON env
+$VIRTUALENV -p $PYTHON3 env
 . env/bin/activate
 
 pip install cffi
@@ -46,10 +48,20 @@ mkdir -p /var/log/mhn
 mkdir -p /etc/supervisor/
 mkdir -p /etc/supervisor/conf.d
 
+cat >> /opt/hpfeeds/users.json <<EOF
+{
+  "my-user-ident": {
+    "owner": "my-owner",
+    "secret": "my-really-strong-passphrase",
+    "subchans": ["chan1"],
+    "pubchans": ["chan2"],
+  }
+}
+EOF
 
 cat >> /etc/supervisor/conf.d/hpfeeds-broker.conf <<EOF 
 [program:hpfeeds-broker]
-command=/opt/hpfeeds/env/bin/python /opt/hpfeeds/broker/feedbroker.py
+command=/opt/hpfeeds/env/bin/python /opt/hpfeeds/env/bin/hpfeeds-broker -e tcp:port=10000 --exporter=0.0.0.0:9431 --auth=/opt/hpfeeds/users.json
 directory=/opt/hpfeeds
 stdout_logfile=/var/log/mhn/hpfeeds-broker.log
 stderr_logfile=/var/log/mhn/hpfeeds-broker.err

--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -55,7 +55,7 @@ cat > /opt/hpfeeds/users.json <<EOF
     "owner": "my-owner",
     "secret": "my-really-strong-passphrase",
     "subchans": ["chan1"],
-    "pubchans": ["chan2"],
+    "pubchans": ["chan2"]
   }
 }
 EOF

--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -16,26 +16,6 @@ if [ -f /etc/debian_version ]; then
     $PIP install virtualenv
     VIRTUALENV=`which virtualenv`
 
-elif [ -f /etc/redhat-release ]; then
-    export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:$PATH
-    yum install -y yum-utils
-    yum-config-manager --add-repo=https://copr.fedoraproject.org/coprs/librehat/shadowsocks/repo/epel-6/librehat-shadowsocks-epel-6.repo
-    yum update -y
-    yum -y install epel-release libffi-devel libssl-devel shadowsocks-libev-devel
-
-    if  [ ! -f /usr/local/bin/python2.7 ]; then
-        $SCRIPTS/install_python2.7.sh
-    fi
-
-    #use python2.7
-    PYTHON=/usr/local/bin/python2.7
-    PIP=/usr/local/bin/pip2.7
-    $PIP install virtualenv
-    VIRTUALENV=/usr/local/bin/virtualenv
-
-    #install supervisor from pip2.7
-    $SCRIPTS/install_supervisord.sh
-
 else
     echo -e "ERROR: Unknown OS\nExiting!"
     exit -1


### PR DESCRIPTION
This PR installs the most up to date version of hpfeeds directly from the https://github.com/hpfeeds/hpfeeds repo. This replaces the https://github.com/pwnlandia/hpfeeds fork that was reliant on Python 2 along with external libraries, which were removed.

The dependencies were also bumped and motor was added.

CentOS support was removed. #19 

This PR closes #18 and will likely result in a lot of unforeseen install failures. In the future, hpfeeds should be installed from pip as a package.